### PR TITLE
ci: configure Maven Central release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5
@@ -23,10 +25,10 @@ jobs:
           distribution: "temurin"
           cache: maven
           server-id: central
-          server-username: CENTRAL_USERNAME
-          server-password: CENTRAL_PASSWORD
+          server-username-env-var: CENTRAL_USERNAME
+          server-password-env-var: CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
+          gpg-passphrase-env-var: MAVEN_GPG_PASSPHRASE
 
       - name: Check release version
         shell: bash
@@ -37,13 +39,18 @@ jobs:
             echo "::error::Tag ${GITHUB_REF_NAME} does not match pom.xml version ${pom_version}."
             exit 1
           fi
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "${GITHUB_SHA}" origin/main; then
+            echo "::error::Release tag ${GITHUB_REF_NAME} must point to a commit that is already in main."
+            exit 1
+          fi
 
       - name: Publish to Maven Central
         run: mvn -B -Pcentral-release clean deploy --file pom.xml
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v7
@@ -51,6 +58,14 @@ jobs:
           name: wscaller-${{ github.ref_name }}
           path: target/wscaller-*.jar
           if-no-files-found: error
+
+      - name: Upload Maven Central bundle
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: maven-central-bundle-${{ github.ref_name }}
+          path: target/central-publishing/central-bundle.zip
+          if-no-files-found: warn
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ mvn -B clean install
 
 The release workflow publishes to Maven Central and attaches the generated JARs to GitHub Releases for tags matching `v*.*.*`, such as `v1.2.0`.
 
+`mvnrepository.com` is not the publishing target; it is a third-party index. Publishing happens through Sonatype Central Portal, then Maven Repository and other indexes pick up the artifact after Maven Central syncs.
+
 ## Branches
 
 - `main`: stable branch for released or release-ready code.
@@ -158,7 +160,20 @@ GPG_PRIVATE_KEY
 GPG_PASSPHRASE
 ```
 
-`CENTRAL_USERNAME` and `CENTRAL_PASSWORD` must come from a Sonatype Central Portal user token. `GPG_PRIVATE_KEY` must be the ASCII-armored private key used to sign Maven artifacts.
+`CENTRAL_USERNAME` and `CENTRAL_PASSWORD` must come from a Sonatype Central Portal user token, not from the account login password. `GPG_PRIVATE_KEY` must be the ASCII-armored private key used to sign Maven artifacts.
+
+Before the first publication, confirm in Sonatype Central Portal that the namespace `io.github.mmilk23` is verified. GitHub-linked Central Portal accounts can usually publish under `io.github.<username>`.
+
+Release flow:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag v1.2.0
+git push origin v1.2.0
+```
+
+The release workflow only publishes tags whose version matches `pom.xml`, and the tagged commit must already be part of `main`.
 
 Optional GitHub repository secret for faster and more reliable OWASP/NVD updates:
 
@@ -208,11 +223,11 @@ wsCaller/
 
 ## Main Dependencies
 
-- Apache Axis2 2.0.0.
+- Apache Axis2 2.0.1.
 - JDOM 2.0.6.1.
-- SLF4J 2.0.17 and Logback 1.5.26.
-- Lombok 1.18.42.
-- JUnit Jupiter 5.14.2 and Mockito 5.21.0 for tests.
+- SLF4J 2.0.17 and Logback 1.6.1.
+- Lombok 1.18.46.
+- JUnit Jupiter 6.1.2 and Mockito 5.23.0 for tests.
 - JaCoCo 0.8.14 for coverage.
 - OWASP Dependency-Check Maven Plugin 12.2.2 for dependency vulnerability scanning.
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
 	<name>wsCaller</name>
 	<description>A lightweight Java library for making secure and generic SOAP web service calls with Apache Axis2.</description>
 	<url>https://github.com/mmilk23/wsCaller</url>
+	<inceptionYear>2026</inceptionYear>
 	<licenses>
 		<license>
 			<name>MIT License</name>
@@ -29,6 +30,14 @@
 		<url>https://github.com/mmilk23/wsCaller</url>
 		<tag>HEAD</tag>
 	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/mmilk23/wsCaller/issues</url>
+	</issueManagement>
+	<ciManagement>
+		<system>GitHub Actions</system>
+		<url>https://github.com/mmilk23/wsCaller/actions</url>
+	</ciManagement>
 	<properties>
 		<maven.compiler.release>25</maven.compiler.release>
 		<project.build.sourceEncoding>Cp1252</project.build.sourceEncoding>
@@ -279,7 +288,10 @@
 						<artifactId>maven-gpg-plugin</artifactId>
 						<version>${maven.gpg.plugin.version}</version>
 						<configuration>
+							<bestPractices>true</bestPractices>
+							<passphraseEnvName>MAVEN_GPG_PASSPHRASE</passphraseEnvName>
 							<gpgArguments>
+								<arg>--batch</arg>
 								<arg>--pinentry-mode</arg>
 								<arg>loopback</arg>
 							</gpgArguments>


### PR DESCRIPTION
## Summary

- Configure the Maven Central release workflow to use the current `actions/setup-java` publishing inputs.
- Harden release publishing so tags must match `pom.xml` and point to commits already in `main`.
- Add Maven Central metadata/documentation updates for release credentials, namespace, and generated artifacts.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow yaml ok"'`
- `mvn -B -Pcentral-release -DskipTests "-Dgpg.skip=true" clean verify --file pom.xml`

## Notes

This PR does not publish anything. Publication only happens after these changes reach `main` and a version tag such as `v1.2.0` is pushed.