### PR TITLE
ci: fix Maven Central GPG release setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,10 @@ jobs:
           distribution: "temurin"
           cache: maven
           server-id: central
-          server-username-env-var: CENTRAL_USERNAME
-          server-password-env-var: CENTRAL_PASSWORD
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase-env-var: MAVEN_GPG_PASSPHRASE
+          gpg-passphrase: GPG_PASSPHRASE
 
       - name: Check release version
         shell: bash
@@ -50,7 +50,7 @@ jobs:
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v7

--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
 						<version>${maven.gpg.plugin.version}</version>
 						<configuration>
 							<bestPractices>true</bestPractices>
-							<passphraseEnvName>MAVEN_GPG_PASSPHRASE</passphraseEnvName>
+							<passphraseEnvName>GPG_PASSPHRASE</passphraseEnvName>
 							<gpgArguments>
 								<arg>--batch</arg>
 								<arg>--pinentry-mode</arg>


### PR DESCRIPTION
## Summary

- Fix `actions/setup-java@v5` inputs used by the Maven Central release workflow.
- Use `GPG_PASSPHRASE` consistently between the workflow secret and `maven-gpg-plugin`'s `passphraseEnvName`.

## Root cause

The failed release run showed `setup-java@v5` ignoring `server-username-env-var`, `server-password-env-var`, and `gpg-passphrase-env-var` because those inputs are not valid for v5. The run then failed during signing with:

```text
gpg: signing failed: Bad passphrase
```

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow yaml ok"'`
- `mvn -B -Pcentral-release -DskipTests "-Dgpg.skip=true" clean verify --file pom.xml`

## Follow-up after merge

After this reaches `main`, recreate/push the `v1.2.0` tag so the release workflow runs from the corrected workflow file.