### PR TITLE
Promote Maven Central release fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,10 @@ jobs:
           distribution: "temurin"
           cache: maven
           server-id: central
-          server-username-env-var: CENTRAL_USERNAME
-          server-password-env-var: CENTRAL_PASSWORD
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase-env-var: MAVEN_GPG_PASSPHRASE
+          gpg-passphrase: GPG_PASSPHRASE
 
       - name: Check release version
         shell: bash
@@ -50,7 +50,7 @@ jobs:
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v7

--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
 						<version>${maven.gpg.plugin.version}</version>
 						<configuration>
 							<bestPractices>true</bestPractices>
-							<passphraseEnvName>MAVEN_GPG_PASSPHRASE</passphraseEnvName>
+							<passphraseEnvName>GPG_PASSPHRASE</passphraseEnvName>
 							<gpgArguments>
 								<arg>--batch</arg>
 								<arg>--pinentry-mode</arg>


### PR DESCRIPTION
## Summary

- Promote the Maven Central release workflow fix from `development` to `main`.
- Align `actions/setup-java@v5` inputs and GPG passphrase environment variable names before retrying the `v1.2.0` release.

## Notes

After this reaches `main`, recreate the `v1.2.0` tag so the release workflow runs from the corrected workflow file.