### PR TITLE
ci: use Maven GPG BC signer for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,6 @@ jobs:
           server-id: central
           server-username: CENTRAL_USERNAME
           server-password: CENTRAL_PASSWORD
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
 
       - name: Check release version
         shell: bash
@@ -50,6 +48,7 @@ jobs:
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Upload build artifact

--- a/pom.xml
+++ b/pom.xml
@@ -289,12 +289,9 @@
 						<version>${maven.gpg.plugin.version}</version>
 						<configuration>
 							<bestPractices>true</bestPractices>
+							<signer>bc</signer>
+							<keyEnvName>GPG_PRIVATE_KEY</keyEnvName>
 							<passphraseEnvName>GPG_PASSPHRASE</passphraseEnvName>
-							<gpgArguments>
-								<arg>--batch</arg>
-								<arg>--pinentry-mode</arg>
-								<arg>loopback</arg>
-							</gpgArguments>
 						</configuration>
 						<executions>
 							<execution>


### PR DESCRIPTION
## Summary

- Switch Maven release signing from external `gpg` to the Maven GPG Plugin `bc` signer.
- Pass `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE` directly to Maven during publication.
- Remove the `setup-java` GPG import inputs from the release workflow.

## Root cause

The corrected `setup-java@v5` inputs removed the previous warnings, but the release still failed during external GnuPG signing:

```text
gpg: signing failed: Bad passphrase
```

Using the `bc` signer avoids relying on the runner's GnuPG keyring/agent and signs from the secret key material directly in Java.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow yaml ok"'`
- `mvn -B -Pcentral-release -DskipTests "-Dgpg.skip=true" clean verify --file pom.xml`