### PR TITLE
Promote BC signer Maven Central release fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,6 @@ jobs:
           server-id: central
           server-username: CENTRAL_USERNAME
           server-password: CENTRAL_PASSWORD
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
 
       - name: Check release version
         shell: bash
@@ -50,6 +48,7 @@ jobs:
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Upload build artifact

--- a/pom.xml
+++ b/pom.xml
@@ -289,12 +289,9 @@
 						<version>${maven.gpg.plugin.version}</version>
 						<configuration>
 							<bestPractices>true</bestPractices>
+							<signer>bc</signer>
+							<keyEnvName>GPG_PRIVATE_KEY</keyEnvName>
 							<passphraseEnvName>GPG_PASSPHRASE</passphraseEnvName>
-							<gpgArguments>
-								<arg>--batch</arg>
-								<arg>--pinentry-mode</arg>
-								<arg>loopback</arg>
-							</gpgArguments>
 						</configuration>
 						<executions>
 							<execution>


### PR DESCRIPTION
## Summary

- Promote the BC signer Maven Central release fix from `development` to `main`.
- This should avoid the external GnuPG `Bad passphrase` failure seen in the previous tag run.

## Notes

After this reaches `main`, the `v1.2.0` tag will be recreated again so the release workflow runs from this corrected workflow.