### PR TITLE
ci: use passphrase-free GPG key for Maven Central release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,6 @@ jobs:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v7

--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,6 @@
 							<bestPractices>true</bestPractices>
 							<signer>bc</signer>
 							<keyEnvName>GPG_PRIVATE_KEY</keyEnvName>
-							<passphraseEnvName>GPG_PASSPHRASE</passphraseEnvName>
 						</configuration>
 						<executions>
 							<execution>


### PR DESCRIPTION
## Summary

- Remove `GPG_PASSPHRASE` from the Maven Central release workflow.
- Keep signing through the Maven GPG Plugin `bc` signer using `GPG_PRIVATE_KEY` only.

## Root cause

The previous CI and BC signer attempts both failed while decrypting the existing passphrase-protected key material. A dedicated CI signing key was generated without passphrase and uploaded to the `GPG_PRIVATE_KEY` Actions secret. Its public key was sent to `keyserver.ubuntu.com`.

Fingerprint:

```text
DECF2DF1AAF7944F57F8B1DF4F4F53E4F271BAC9
```

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow yaml ok"'`
- `mvn -B -Pcentral-release -DskipTests "-Dgpg.skip=true" clean verify --file pom.xml`