### PR TITLE
Promote passphrase-free Maven Central release key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,6 @@ jobs:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v7

--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,6 @@
 							<bestPractices>true</bestPractices>
 							<signer>bc</signer>
 							<keyEnvName>GPG_PRIVATE_KEY</keyEnvName>
-							<passphraseEnvName>GPG_PASSPHRASE</passphraseEnvName>
 						</configuration>
 						<executions>
 							<execution>


### PR DESCRIPTION
## Summary

- Promote the passphrase-free CI signing key release workflow change from `development` to `main`.
- This removes `GPG_PASSPHRASE` from the release path and signs with the Maven GPG Plugin `bc` signer using `GPG_PRIVATE_KEY` only.

## Notes

After this reaches `main`, the `v1.2.0` tag will be recreated again to retry Maven Central publication.