### PR TITLE
Document API usage and release 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,24 @@
 - Utility classes for common string and object parsing operations.
 - Maven build configured for Java 25.
 
+## Advantages
+
+- **No generated stubs required**: call SOAP services directly when you know the endpoint, namespace, operation, and parameter names.
+- **Small public API**: most integrations only need `SecureWebServiceCaller`, a `Map<String, Object>`, and basic error handling.
+- **Lower integration overhead**: useful for legacy SOAP services where generating and maintaining client code for every WSDL is inconvenient.
+- **Optional security header**: send WS-Security username/password credentials only when the target service requires them.
+- **Easy to test**: the Axis2 call path can be isolated with wrappers, stubs, Mockito, or custom subclasses.
+- **AI-friendly usage contract**: the repository includes `docs/AI_USAGE.md` and `llms.txt` so coding agents can use the library with fewer assumptions.
+
 ## Requirements
 
 - JDK 25.
 - Apache Maven 3.9 or newer.
 - Access to the target SOAP endpoint for integration/manual calls.
+
+### Java Compatibility Note
+
+This project is currently built and validated with JDK 25. The original version of the library was written for JDK 8, so the source code may still be adaptable to earlier Java versions by changing the Maven compiler configuration and rebuilding from source. If you need Java 8 compatibility, run the full test suite after changing the target release.
 
 On this workstation, the JDK 25 path used for validation is:
 
@@ -50,7 +63,7 @@ mvn -B clean install
 The generated JAR is written to:
 
 ```text
-target/wscaller-1.2.0.jar
+target/wscaller-1.2.1.jar
 ```
 
 ## Maven Dependency
@@ -61,7 +74,7 @@ The Maven coordinates for this project are:
 <dependency>
     <groupId>io.github.mmilk23</groupId>
     <artifactId>wscaller</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
 </dependency>
 ```
 
@@ -71,7 +84,7 @@ Before the first Maven Central publication is available, another Maven project o
 mvn -B clean install
 ```
 
-The release workflow publishes to Maven Central and attaches the generated JARs to GitHub Releases for tags matching `v*.*.*`, such as `v1.2.0`.
+The release workflow publishes to Maven Central and attaches the generated JARs to GitHub Releases for tags matching `v*.*.*`, such as `v1.2.1`.
 
 `mvnrepository.com` is not the publishing target; it is a third-party index. Publishing happens through Sonatype Central Portal, then Maven Repository and other indexes pick up the artifact after Maven Central syncs.
 
@@ -83,6 +96,10 @@ The release workflow publishes to Maven Central and attaches the generated JARs 
 Open feature and dependency-update pull requests against `development`. Promote `development` to `main` with a pull request after the build, dependency review, OWASP Dependency-Check, Snyk, and CodeQL checks are green.
 
 ## Usage
+
+For detailed end-user API documentation, see [docs/API.md](docs/API.md).
+
+For AI agents and automation tools that need a compact implementation contract, see [docs/AI_USAGE.md](docs/AI_USAGE.md) and [llms.txt](llms.txt).
 
 ```java
 import com.milklabs.wscall.SecureWebServiceCaller;
@@ -169,8 +186,8 @@ Release flow:
 ```bash
 git switch main
 git pull --ff-only origin main
-git tag v1.2.0
-git push origin v1.2.0
+git tag v1.2.1
+git push origin v1.2.1
 ```
 
 The release workflow only publishes tags whose version matches `pom.xml`, and the tagged commit must already be part of `main`.

--- a/docs/AI_USAGE.md
+++ b/docs/AI_USAGE.md
@@ -1,0 +1,157 @@
+# wsCaller Guide For AI Agents
+
+This file is written for AI coding agents and automation tools that need to use `wsCaller` correctly from Java code.
+
+## Library Identity
+
+- Name: `wsCaller`
+- Maven coordinates: `io.github.mmilk23:wscaller:1.2.1`
+- Purpose: generic synchronous SOAP calls through Apache Axis2
+- Main package: `com.milklabs.wscall`
+- Primary class: `SecureWebServiceCaller`
+
+## Java Compatibility
+
+- Current build target: JDK 25.
+- Historical note: the original library was written for JDK 8.
+- Do not claim Java 8 compatibility unless the Maven compiler target is changed and the full test suite passes.
+
+## Correct Use Pattern
+
+```java
+import com.milklabs.wscall.SecureWebServiceCaller;
+import com.milklabs.wscall.WebServiceException;
+import org.apache.axis2.addressing.EndpointReference;
+
+import java.util.HashMap;
+import java.util.Map;
+
+SecureWebServiceCaller caller = new SecureWebServiceCaller(
+        new EndpointReference("https://example.com/soap/service"),
+        "http://example.com/namespace",
+        "ns"
+);
+
+Map<String, Object> params = new HashMap<>();
+params.put("elementName", "elementValue");
+
+String xml = caller.chamarWebService("OperationName", params, null, null);
+```
+
+With WS-Security UsernameToken:
+
+```java
+String xml = caller.chamarWebService(
+        "OperationName",
+        params,
+        username,
+        password
+);
+```
+
+## API Contract
+
+Constructor:
+
+```java
+SecureWebServiceCaller(EndpointReference urlServico, String namespace, String prefixo)
+```
+
+Call method:
+
+```java
+String chamarWebService(
+        String metodo,
+        Map<String, Object> params,
+        String username,
+        String password
+) throws WebServiceException
+```
+
+Behavior:
+
+- sends SOAP 1.2;
+- performs one synchronous request;
+- returns raw XML as `String`;
+- wraps `AxisFault` and unexpected exceptions in `WebServiceException`;
+- adds WS-Security only when `username != null && password != null`;
+- skips request parameters whose value is `null`;
+- cleans up Axis2 transport resources after each call.
+
+## Parameter Serialization Rules
+
+Important: preserve these rules when generating code.
+
+| Java value in `params` | XML behavior |
+| --- | --- |
+| `null` | Parameter is omitted. |
+| `String` | Parameter element receives text content. |
+| `HashMap` | Parameter becomes nested map entries. |
+| `Hashtable` | Parameter becomes nested map entries. |
+| Other scalar types | Parameter element is created without text content by the current implementation. |
+
+Therefore:
+
+- Convert numbers, booleans, dates, enums, and IDs to `String` before putting them in `params`.
+- Use parameter names exactly as required by the SOAP operation.
+- Do not assume WSDL parsing or Java type generation exists.
+- Do not send JSON.
+- Do not expect the library to deserialize the response.
+
+Good:
+
+```java
+params.put("customerId", String.valueOf(customerId));
+params.put("active", Boolean.toString(active));
+params.put("referenceDate", date.format(DateTimeFormatter.ISO_LOCAL_DATE));
+```
+
+Avoid:
+
+```java
+params.put("customerId", customerId);
+params.put("active", active);
+params.put("referenceDate", localDate);
+```
+
+## Response Handling
+
+`chamarWebService` returns XML. Generated code should parse XML with a real XML parser.
+
+Security recommendations:
+
+- disable external DTD/entity access when supported by the parser;
+- avoid regex for XML;
+- handle namespaces explicitly.
+
+## Error Handling Pattern
+
+```java
+try {
+    String xml = caller.chamarWebService(operation, params, username, password);
+    return parseResponse(xml);
+} catch (WebServiceException e) {
+    Throwable cause = e.getCause();
+    throw new IllegalStateException(
+            "SOAP call failed: " + (cause != null ? cause.getMessage() : e.getMessage()),
+            e
+    );
+}
+```
+
+## Known Constraints
+
+- Synchronous only.
+- SOAP 1.2 only in the current implementation.
+- Internal timeout is `600` milliseconds.
+- No automatic WSDL introspection.
+- No typed request/response model generation.
+- No automatic response parsing.
+- Map serialization creates a repeated wrapper element before `entry/key/value`.
+
+## Files To Inspect
+
+- Main implementation: `src/main/java/com/milklabs/wscall/SecureWebServiceCaller.java`
+- Exception type: `src/main/java/com/milklabs/wscall/WebServiceException.java`
+- Example: `src/main/java/com/milklabs/exemplo/ExemploChamadaWS.java`
+- User documentation: `docs/API.md`

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,318 @@
+# wsCaller API Guide
+
+`wsCaller` is a small Java library for calling SOAP web services without generating a Java stub for each WSDL. The library builds a SOAP 1.2 request from a method name and a `Map<String, Object>`, sends it with Apache Axis2, and returns the SOAP response as XML text.
+
+Use this guide when you want to call an existing SOAP endpoint from an application.
+
+## When To Use
+
+Use `wsCaller` when:
+
+- the target service exposes a SOAP endpoint;
+- you know the endpoint URL, namespace, operation name, and input element names;
+- you want a simple synchronous call;
+- the request can be represented as strings and simple map entries.
+
+Do not use `wsCaller` as a REST/JSON client. It does not parse WSDL files, generate typed clients, or convert responses into Java objects automatically.
+
+## Installation
+
+Add the Maven dependency:
+
+```xml
+<dependency>
+    <groupId>io.github.mmilk23</groupId>
+    <artifactId>wscaller</artifactId>
+    <version>1.2.1</version>
+</dependency>
+```
+
+If the artifact is not available from Maven Central yet, install this project locally first:
+
+```bash
+mvn -B clean install
+```
+
+## Requirements
+
+- JDK 25.
+- Apache Maven 3.9 or newer.
+- Network access to the SOAP endpoint.
+- SOAP contract details from the service provider or WSDL.
+
+## Quick Start
+
+This example calls the public CountryInfo SOAP service and asks for Brazil's currency.
+
+```java
+import com.milklabs.wscall.SecureWebServiceCaller;
+import com.milklabs.wscall.WebServiceException;
+import org.apache.axis2.addressing.EndpointReference;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Main {
+    public static void main(String[] args) throws WebServiceException {
+        SecureWebServiceCaller caller = new SecureWebServiceCaller(
+                new EndpointReference("http://webservices.oorsprong.org/websamples.countryinfo/CountryInfoService.wso"),
+                "http://www.oorsprong.org/websamples.countryinfo",
+                "xs"
+        );
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("sCountryISOCode", "BR");
+
+        String xml = caller.chamarWebService("CountryCurrency", params, null, null);
+        System.out.println(xml);
+    }
+}
+```
+
+## Main Class
+
+### `SecureWebServiceCaller`
+
+Package:
+
+```java
+com.milklabs.wscall.SecureWebServiceCaller
+```
+
+Constructor:
+
+```java
+public SecureWebServiceCaller(
+        EndpointReference urlServico,
+        String namespace,
+        String prefixo
+)
+```
+
+Parameters:
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `urlServico` | `org.apache.axis2.addressing.EndpointReference` | SOAP endpoint URL. This is usually the endpoint address, not the WSDL URL. |
+| `namespace` | `String` | XML namespace used by the SOAP operation. |
+| `prefixo` | `String` | Namespace prefix used when creating the operation element. |
+
+Example:
+
+```java
+SecureWebServiceCaller caller = new SecureWebServiceCaller(
+        new EndpointReference("https://example.com/soap/service"),
+        "http://example.com/contract/v1",
+        "v1"
+);
+```
+
+## Calling A Service
+
+Method:
+
+```java
+public String chamarWebService(
+        String metodo,
+        Map<String, Object> params,
+        String username,
+        String password
+) throws WebServiceException
+```
+
+Parameters:
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `metodo` | `String` | Yes | SOAP operation element name. |
+| `params` | `Map<String, Object>` | No | Request parameters. Use `null` or an empty map for operations without parameters. |
+| `username` | `String` | No | WS-Security username. A security header is added only when both `username` and `password` are non-null. |
+| `password` | `String` | No | WS-Security password. |
+
+Returns:
+
+- `String` containing the XML returned by Axis2.
+- `null` only if an override of the protected synchronous method returns `null`.
+
+Throws:
+
+- `WebServiceException` when Axis2 raises an `AxisFault` or when an unexpected error occurs during the call.
+
+## Parameter Mapping
+
+`wsCaller` creates the request body from `params`.
+
+For each `params` entry:
+
+- the map key becomes an XML element name;
+- `null` values are ignored and are not sent;
+- `String` values become text content;
+- `HashMap` and `Hashtable` values become nested `entry/key/value` elements;
+- other scalar types are not converted into text by the current implementation, so pass numbers, booleans, dates, and enums as strings.
+
+Recommended scalar usage:
+
+```java
+Map<String, Object> params = new HashMap<>();
+params.put("customerId", "12345");
+params.put("active", "true");
+params.put("amount", "99.90");
+```
+
+Map parameter usage:
+
+```java
+Map<String, Object> filters = new HashMap<>();
+filters.put("status", "ACTIVE");
+filters.put("region", "BR");
+
+Map<String, Object> params = new HashMap<>();
+params.put("filters", filters);
+```
+
+The map parameter is serialized with entries similar to:
+
+```xml
+<filters>
+    <filters>
+        <entry>
+            <key>status</key>
+            <value>ACTIVE</value>
+        </entry>
+        <entry>
+            <key>region</key>
+            <value>BR</value>
+        </entry>
+    </filters>
+</filters>
+```
+
+## WS-Security Username And Password
+
+When both `username` and `password` are provided, `wsCaller` adds a SOAP 1.2 WS-Security `Security` header with `UsernameToken`, `Username`, and `Password`.
+
+```java
+String xml = caller.chamarWebService(
+        "ConsultarCliente",
+        params,
+        System.getenv("SOAP_USERNAME"),
+        System.getenv("SOAP_PASSWORD")
+);
+```
+
+When either value is `null`, no security header is added.
+
+## Reading The Response
+
+The library returns raw XML. Parse the XML according to the service contract.
+
+For XML parsing, prefer a namespace-aware parser and disable external entity access when possible. The sample project uses JDOM2 with external DTD access disabled.
+
+```java
+String xml = caller.chamarWebService("CountryCurrency", params, null, null);
+// Parse xml into your own DTO/VO here.
+```
+
+See [ExemploChamadaWS.java](../src/main/java/com/milklabs/exemplo/ExemploChamadaWS.java) for a complete example.
+
+## Error Handling
+
+Wrap calls in `try/catch` and inspect the cause when needed.
+
+```java
+try {
+    String xml = caller.chamarWebService("ConsultarCliente", params, username, password);
+    System.out.println(xml);
+} catch (WebServiceException e) {
+    Throwable cause = e.getCause();
+    System.err.println("SOAP call failed: " + (cause != null ? cause.getMessage() : e.getMessage()));
+}
+```
+
+`AxisFault` errors are wrapped as `WebServiceException`. The implementation logs SOAP fault code and detail when Axis2 provides them.
+
+## Public Support Classes
+
+### `WebServiceException`
+
+Package:
+
+```java
+com.milklabs.wscall.WebServiceException
+```
+
+Checked exception used by `SecureWebServiceCaller`.
+
+Constructors:
+
+```java
+public WebServiceException()
+public WebServiceException(Exception e)
+public WebServiceException(String message)
+public WebServiceException(String message, Throwable cause)
+public WebServiceException(Throwable cause)
+```
+
+### `ServiceClientWrapper`
+
+Package:
+
+```java
+com.milklabs.wscall.ServiceClientWrapper
+```
+
+Thin wrapper around Axis2 `ServiceClient`. It is mainly useful for tests and extension points.
+
+Methods:
+
+```java
+public OMElement sendReceive(OMElement request) throws AxisFault
+public void cleanup() throws AxisFault
+public void cleanupTransport() throws AxisFault
+```
+
+### `ServiceClientWrapperStub`
+
+Package:
+
+```java
+com.milklabs.wscall.ServiceClientWrapperStub
+```
+
+Simple test stub that can return a mock `OMElement` response or simulate an `AxisFault`.
+
+## Utilities
+
+The `com.milklabs.wscall.util` package contains small parsing and string helpers used internally by the library. They are public, but they are not required for normal SOAP calls.
+
+Notable methods:
+
+```java
+StringUtils.isEmptyOrNull(Object value)
+StringUtils.isEmptyTrimOrNull(Object value)
+StringUtils.toString(Object value)
+ObjectParser.parseInt(Object value)
+ObjectParser.parseLong(Object value)
+ObjectParser.parseDouble(Object value)
+ObjectParser.parseBoolean(Object value)
+ObjectParser.parseDate(String pattern, String date)
+```
+
+## Operational Notes
+
+- Calls are synchronous.
+- SOAP version is set to SOAP 1.2.
+- HTTP gzip is disabled.
+- HTTP client reuse is disabled.
+- The internal timeout is currently `600` milliseconds.
+- `ServiceClient.cleanup()` and `cleanupTransport()` are called after each request.
+
+## Troubleshooting
+
+| Symptom | Likely cause | What to check |
+| --- | --- | --- |
+| SOAP fault from server | Wrong method name, namespace, endpoint, or payload shape | Compare generated request names with the WSDL. |
+| Empty values in request | Non-string scalar value passed in `params` | Convert scalar values to `String` before calling. |
+| Authentication failure | Missing or incompatible WS-Security header | Pass both username and password, and confirm the service expects UsernameToken. |
+| Connection timeout | Endpoint unavailable or timeout too low | Confirm endpoint reachability and service latency. |
+| XML parsing error | Response namespace or shape differs from expectation | Parse by XML structure and namespace instead of fixed string matching. |

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,66 @@
+# wsCaller
+
+> Java library for synchronous SOAP 1.2 calls without generated WSDL stubs.
+
+## Use
+
+Main class:
+
+```java
+com.milklabs.wscall.SecureWebServiceCaller
+```
+
+Maven dependency:
+
+```xml
+<dependency>
+    <groupId>io.github.mmilk23</groupId>
+    <artifactId>wscaller</artifactId>
+    <version>1.2.1</version>
+</dependency>
+```
+
+Minimal Java usage:
+
+```java
+SecureWebServiceCaller caller = new SecureWebServiceCaller(
+        new EndpointReference("https://example.com/soap/service"),
+        "http://example.com/namespace",
+        "ns"
+);
+
+Map<String, Object> params = new HashMap<>();
+params.put("elementName", "elementValue");
+
+String xml = caller.chamarWebService("OperationName", params, null, null);
+```
+
+With WS-Security UsernameToken:
+
+```java
+String xml = caller.chamarWebService("OperationName", params, username, password);
+```
+
+## Java Compatibility
+
+- Current build target: JDK 25.
+- Historical note: the original library was written for JDK 8.
+- Do not claim Java 8 compatibility unless the Maven compiler target is changed and the full test suite passes.
+
+## Contract
+
+- `params` keys are SOAP request element names.
+- `String` values are serialized as element text.
+- `null` values are omitted.
+- `HashMap` and `Hashtable` values are serialized as nested `entry/key/value` items.
+- Convert numeric, boolean, date, enum, and ID values to `String` before adding them to `params`.
+- Return value is raw XML as `String`.
+- Parse responses with an XML parser; do not use JSON parsing.
+- Exceptions are wrapped in `com.milklabs.wscall.WebServiceException`.
+
+## Docs
+
+- Human API guide: `docs/API.md`
+- AI agent guide: `docs/AI_USAGE.md`
+- Example code: `src/main/java/com/milklabs/exemplo/ExemploChamadaWS.java`
+- Main implementation: `src/main/java/com/milklabs/wscall/SecureWebServiceCaller.java`

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.mmilk23</groupId>
 	<artifactId>wscaller</artifactId>
-	<version>1.2.0</version>
+	<version>1.2.1</version>
 	<packaging>jar</packaging>
 	<name>wsCaller</name>
 	<description>A lightweight Java library for making secure and generic SOAP web service calls with Apache Axis2.</description>

--- a/src/main/java/com/milklabs/wscall/SecureWebServiceCaller.java
+++ b/src/main/java/com/milklabs/wscall/SecureWebServiceCaller.java
@@ -22,11 +22,14 @@ import org.slf4j.LoggerFactory;
 import com.milklabs.wscall.util.StringUtils;
 
 /**
- * Implements generic calls to any webservice, whitout generate stubs o any
- * other bullshit
- * 
+ * Generic SOAP web service caller based on Apache Axis2.
+ * <p>
+ * This class builds a SOAP 1.2 request from an operation name and a parameter
+ * map, sends it synchronously to the configured endpoint, and returns the raw
+ * XML response. A WS-Security UsernameToken header is added when both username
+ * and password are provided.
+ *
  * @author mmilk23
- * 
  */
 public class SecureWebServiceCaller {
 
@@ -38,10 +41,12 @@ public class SecureWebServiceCaller {
 	protected static long timeoutHttp = 600;
 
 	/**
-	 * 
-	 * @param urlServico Endpoint
-	 * @param namespace
-	 * @param prefixo
+	 * Creates a caller for a SOAP endpoint.
+	 *
+	 * @param urlServico SOAP endpoint URL, usually the service endpoint rather than
+	 *                   the WSDL URL.
+	 * @param namespace  XML namespace used by the SOAP operation.
+	 * @param prefixo    Namespace prefix used for the operation element.
 	 */
 	public SecureWebServiceCaller(EndpointReference urlServico, String namespace, String prefixo) {
 		log.debug("[SecureWebServiceCaller] constructor called, urlServico: [{}] namespace: [{}] prefixo: [{}]", urlServico, namespace, prefixo);
@@ -57,12 +62,15 @@ public class SecureWebServiceCaller {
 	 */
 
 	/**
-	 * Chamada sincrona a um Web Service
-	 * 
-	 * @param metodo
-	 * @param params
-	 * @return OMElement
-	 * @throws WebServiceException
+	 * Performs a synchronous SOAP web service call and returns the response as an
+	 * {@link OMElement}.
+	 *
+	 * @param metodo     SOAP operation element name.
+	 * @param params     request parameters. Null values are ignored.
+	 * @param wsUsername optional WS-Security username.
+	 * @param wsPassword optional WS-Security password.
+	 * @return SOAP response element.
+	 * @throws WebServiceException if Axis2 or request processing fails.
 	 */
 	@SuppressWarnings("rawtypes")
 
@@ -185,14 +193,17 @@ public class SecureWebServiceCaller {
 	}
 
 	/**
-	 * Chamada sincrona a um Web Service
-	 * 
-	 * 
-	 * @param metodo
-	 * @param params
-	 * @param username
-	 * @return representacao XML com a resposta do servico
-	 * @throws WebServiceException
+	 * Performs a synchronous SOAP web service call and returns the response XML.
+	 *
+	 * @param metodo   SOAP operation element name.
+	 * @param params   request parameters. Use string values for scalar SOAP
+	 *                 elements; null values are ignored.
+	 * @param username optional WS-Security username. Header is added only when both
+	 *                 username and password are non-null.
+	 * @param password optional WS-Security password.
+	 * @return XML representation of the service response, or null when the
+	 *         underlying synchronous call returns null.
+	 * @throws WebServiceException if Axis2 or request processing fails.
 	 */
 	public String chamarWebService(String metodo, Map<String, Object> params, String username, String password)
 			throws WebServiceException {


### PR DESCRIPTION
## Summary

- add end-user API documentation in `docs/API.md`
- add AI/LLM usage documentation in `docs/AI_USAGE.md` and `llms.txt`
- document library advantages and Java compatibility notes in `README.md`
- clean up public Javadocs for `SecureWebServiceCaller`
- bump project version to `1.2.1` for the next release

## Validation

- `mvn -B clean verify` with `JAVA_HOME=C:\dev\aws-jdk25.0.4_7`
- 77 tests passed, 0 failures
