### PR TITLE
fix: correct Dependency-Check data path

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      DEPENDENCY_CHECK_DATA: ${{ runner.temp }}/dependency-check-data
+      DEPENDENCY_CHECK_DATA: ${{ github.workspace }}/.dependency-check-data
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Fixes the invalid GitHub Actions expression introduced in the Dependency-Check workflow. `runner.temp` is not available in a job-level `env` expression, so the persistent Dependency-Check data directory now uses `${{ github.workspace }}/.dependency-check-data`, which is valid in this context and remains suitable for `actions/cache`.