### PR TITLE
fix: prevent incomplete OWASP cache after timeout

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -14,7 +14,7 @@ jobs:
   dependency-check:
     name: OWASP Dependency-Check
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
     env:
       DEPENDENCY_CHECK_DATA: ${{ github.workspace }}/.dependency-check-data
 
@@ -39,9 +39,9 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ env.DEPENDENCY_CHECK_DATA }}
-          key: dependency-check-data-${{ runner.os }}-${{ steps.cache-key.outputs.week }}
+          key: dependency-check-data-v2-${{ runner.os }}-${{ steps.cache-key.outputs.week }}
           restore-keys: |
-            dependency-check-data-${{ runner.os }}-
+            dependency-check-data-v2-${{ runner.os }}-
 
       - name: Run OWASP Dependency-Check
         shell: bash
@@ -69,11 +69,11 @@ jobs:
           "${args[@]}"
 
       - name: Save OWASP Dependency-Check data
-        if: always() && steps.dependency-check-cache.outputs.cache-hit != 'true'
+        if: success() && steps.dependency-check-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: ${{ env.DEPENDENCY_CHECK_DATA }}
-          key: dependency-check-data-${{ runner.os }}-${{ steps.cache-key.outputs.week }}
+          key: dependency-check-data-v2-${{ runner.os }}-${{ steps.cache-key.outputs.week }}
 
       - name: Upload OWASP Dependency-Check report
         if: always()


### PR DESCRIPTION
Adjusts the OWASP Dependency-Check workflow after observing the initial NVD download exceed the 20-minute timeout.

Changes:
- increases job timeout from 20 to 60 minutes for the initial NVD bootstrap;
- moves the Dependency-Check cache namespace to `v2`, avoiding reuse of the incomplete cache saved by the timed-out run;
- saves Dependency-Check data only when the preceding analysis completes successfully, preventing partial/corrupt NVD data from becoming the weekly cache.

Once a complete weekly cache exists, pull-request runs can reuse it with `autoUpdate=false` and should be substantially faster.